### PR TITLE
fix consoleView disposer

### DIFF
--- a/changelog/@unreleased/pr-8.v2.yml
+++ b/changelog/@unreleased/pr-8.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[intellij plugin] Fix consoleView disposer'
+  links:
+  - https://github.com/palantir/gradle-jdks-idea-plugin/pull/8

--- a/gradle-jdks-idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksProjectService.java
+++ b/gradle-jdks-idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksProjectService.java
@@ -88,6 +88,7 @@ public final class GradleJdksProjectService implements Disposable {
             ContentFactory contentFactory = ContentFactory.getInstance();
             Content content = contentFactory.createContent(newConsoleView.getComponent(), "", false);
             toolWindow.getContentManager().addContent(content);
+            content.setDisposer(newConsoleView);
         });
 
         return newConsoleView;
@@ -217,10 +218,5 @@ public final class GradleJdksProjectService implements Disposable {
     }
 
     @Override
-    public void dispose() {
-        ConsoleView view = consoleView.get();
-        if (view != null) {
-            view.dispose();
-        }
-    }
+    public void dispose() {}
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Got the following exception when I switched intellij tabs
```
com.intellij.serviceContainer.AlreadyDisposedException: Already disposed: Project(name=<project>, containerState=DISPOSED, componentStore=/Volumes/git/<project>) (disposed)
    at com.intellij.serviceContainer.ComponentManagerImpl.getMessageBus(ComponentManagerImpl.kt:290)
    at com.intellij.execution.impl.ConsoleViewImpl.<init>(ConsoleViewImpl.java:189)
    at com.intellij.execution.impl.ConsoleViewImpl.<init>(ConsoleViewImpl.java:164)
    at com.intellij.execution.filters.TextConsoleBuilderImpl.createConsole(TextConsoleBuilderImpl.java:39)
    at com.intellij.execution.filters.TextConsoleBuilderImpl.getConsole(TextConsoleBuilderImpl.java:31)
    at com.palantir.gradle.jdks.GradleJdksProjectService.initConsoleView(GradleJdksProjectService.java:80)
    at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:186)
    at com.palantir.gradle.jdks.GradleJdksProjectService.dispose(GradleJdksProjectService.java:221)
    at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:131)
    at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:163)
    at com.intellij.openapi.util.Disposer.dispose(Disposer.java:205)
    at com.intellij.openapi.util.Disposer.dispose(Disposer.java:193)
    at com.intellij.serviceContainer.ComponentManagerImpl.dispose(ComponentManagerImpl.kt:1161)
    at com.intellij.openapi.project.impl.ProjectImpl.dispose(ProjectImpl.kt:321)
    at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:131)
    at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:163)
    at com.intellij.openapi.util.Disposer.dispose(Disposer.java:205)
    at com.intellij.openapi.util.Disposer.dispose(Disposer.java:193)
    at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$lambda$15(ProjectManagerImpl.kt:423)
    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction$lambda$4(AnyThreadWriteThreadingSupport.kt:318)
    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction(AnyThreadWriteThreadingSupport.kt:328)
    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction(AnyThreadWriteThreadingSupport.kt:318)
    at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:890)
    at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject(ProjectManagerImpl.kt:406)
    at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$default(ProjectManagerImpl.kt:328)
    at com.intellij.openapi.project.impl.ProjectManagerImpl.closeAndDispose(ProjectManagerImpl.kt:435)
    at com.intellij.openapi.wm.impl.CloseProjectWindowHelper.closeProjectAndShowWelcomeFrameIfNoProjectOpened(CloseProjectWindowHelper.kt:57)
    at com.intellij.openapi.wm.impl.CloseProjectWindowHelper.windowClosing(CloseProjectWindowHelper.kt:44)
    at com.intellij.openapi.wm.impl.ProjectFrameHelper.windowClosing(ProjectFrameHelper.kt:428)
    at com.intellij.openapi.wm.impl.WindowCloseListener.windowClosing(ProjectFrameHelper.kt:451)
    at java.desktop/java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:357)
    at java.desktop/java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:357)
    at java.desktop/java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:357)
    at java.desktop/java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:357)
    at java.desktop/java.awt.Window.processWindowEvent(Window.java:2115)
    at java.desktop/javax.swing.JFrame.processWindowEvent(JFrame.java:298)
    at java.desktop/java.awt.Window.processEvent(Window.java:2074)
    at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5032)
    at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
    at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2810)
    at java.desktop/java.awt.Component.dispatchEvent(Component.java:4860)
    at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:783)
    at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:728)
    at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
    at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
    at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
    at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
    at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:755)
    at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:753)
    at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
    at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
    at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:752)
    at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:696)
    at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$16(IdeEventQueue.kt:590)
    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithoutImplicitRead(AnyThreadWriteThreadingSupport.kt:117)
    at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:590)
    at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:73)
    at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:357)
    at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:356)
    at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:843)
    at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:356)
    at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:351)
    at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke$lambda$0(IdeEventQueue.kt:1035)
    at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)
    at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:910)
    at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
    at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
    at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
    at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
    at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:1036)
    at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:114)
    at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1036)
    at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$10(IdeEventQueue.kt:351)
    at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:397)
    at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
    at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
    at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
    at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
    at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
    at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```

## After this PR
same as: https://github.com/palantir/gradle-jdks/pull/437
<!-- User-facing outcomes this PR delivers go below -->
Following the docs on how to dispose consoleViews correctly: https://plugins.jetbrains.com/docs/intellij/tool-windows.html#contents-tabs
==COMMIT_MSG==
[intellij plugin] Fix consoleView disposer
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

